### PR TITLE
offset noise generation to create big maps from small ones

### DIFF
--- a/src/main/java/com/agonyengine/noise/Main.java
+++ b/src/main/java/com/agonyengine/noise/Main.java
@@ -1,13 +1,10 @@
 package com.agonyengine.noise;
 
 import com.agonyengine.noise.image.ImageFactory;
-import com.agonyengine.noise.impl.DiamondSquareNoise;
 import com.agonyengine.noise.impl.FbmNoise;
 import com.agonyengine.noise.impl.FbmParameters;
-import com.agonyengine.noise.impl.OpenSimplex2Noise;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 
 public class Main {
     public static void main(String ... args) throws IOException {
@@ -18,15 +15,20 @@ public class Main {
                 0.5,
                 3
         );
-        NoiseGenerator noise = new FbmNoise(parameters);
+        OffsetNoiseGenerator noise = new FbmNoise(parameters);
 //        NoiseGenerator noise = new DiamondSquareNoise();
 //        NoiseGenerator noise = new OpenSimplex2Noise();
 //        NoiseMap map = noise.generate("World Map", 257, 257);
         NoiseMap elevation = noise.generate("Elevation Map", 257, 257);
         NoiseMap moisture = noise.generate("Moisture Map", 257, 257);
 
+        // Generate a second map immediately to the right (east?) of the first one.
+        NoiseMap elevationRight = noise.generate("Elevation Map", 257, 257, 257, 0);
+        NoiseMap moistureRight = noise.generate("Moisture Map", 257, 257, 257, 0);
+
 //        ImageFactory.drawMono(map);
 //        ImageFactory.drawQuarters(map);
         ImageFactory.drawBiomes(elevation, moisture);
+        ImageFactory.drawBiomes(elevationRight, moistureRight);
     }
 }

--- a/src/main/java/com/agonyengine/noise/OffsetNoiseGenerator.java
+++ b/src/main/java/com/agonyengine/noise/OffsetNoiseGenerator.java
@@ -1,0 +1,5 @@
+package com.agonyengine.noise;
+
+public interface OffsetNoiseGenerator extends NoiseGenerator {
+    NoiseMap generate(String seedPrefix, int width, int height, int offsetX, int offsetY);
+}

--- a/src/main/java/com/agonyengine/noise/impl/FbmNoise.java
+++ b/src/main/java/com/agonyengine/noise/impl/FbmNoise.java
@@ -1,10 +1,10 @@
 package com.agonyengine.noise.impl;
 
-import com.agonyengine.noise.NoiseGenerator;
+import com.agonyengine.noise.OffsetNoiseGenerator;
 import com.agonyengine.noise.NoiseMap;
 import com.agonyengine.noise.thirdparty.FastNoiseLite;
 
-public class FbmNoise implements NoiseGenerator {
+public class FbmNoise implements OffsetNoiseGenerator {
     private final FbmParameters parameters;
     private final FastNoiseLite noiseGenerator = new FastNoiseLite();
 
@@ -15,6 +15,11 @@ public class FbmNoise implements NoiseGenerator {
 
     @Override
     public NoiseMap generate(final String seedPrefix, final int width, final int height) {
+        return generate(seedPrefix, width, height, 0, 0);
+    }
+
+    @Override
+    public NoiseMap generate(final String seedPrefix, final int width, final int height, final int offsetX, final int offsetY) {
         double[][] result = new double[width][height];
         double frequency = parameters.getBaseFrequency();
         double amplitude = parameters.getBaseAmplitude();
@@ -24,7 +29,7 @@ public class FbmNoise implements NoiseGenerator {
 
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height; y++) {
-                    result[x][y] += amplitude * noiseGenerator.GetNoise(x * frequency, y * frequency);
+                    result[x][y] += amplitude * noiseGenerator.GetNoise((x + offsetX) * frequency, (y + offsetY) * frequency);
                 }
             }
 

--- a/src/main/java/com/agonyengine/noise/impl/OpenSimplex2Noise.java
+++ b/src/main/java/com/agonyengine/noise/impl/OpenSimplex2Noise.java
@@ -1,10 +1,10 @@
 package com.agonyengine.noise.impl;
 
-import com.agonyengine.noise.NoiseGenerator;
+import com.agonyengine.noise.OffsetNoiseGenerator;
 import com.agonyengine.noise.NoiseMap;
 import com.agonyengine.noise.thirdparty.FastNoiseLite;
 
-public class OpenSimplex2Noise implements NoiseGenerator {
+public class OpenSimplex2Noise implements OffsetNoiseGenerator {
     private final FastNoiseLite noiseGenerator = new FastNoiseLite();
 
     public OpenSimplex2Noise() {
@@ -13,13 +13,18 @@ public class OpenSimplex2Noise implements NoiseGenerator {
 
     @Override
     public NoiseMap generate(final String seedPrefix, final int width, final int height) {
+        return generate(seedPrefix, width, height, 0, 0);
+    }
+
+    @Override
+    public NoiseMap generate(final String seedPrefix, final int width, final int height, final int offsetX, final int offsetY) {
         final double[][] map = new double[width][height];
 
         noiseGenerator.SetSeed(seedPrefix.hashCode());
 
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                map[x][y] = noiseGenerator.GetNoise(x, y);
+                map[x][y] = noiseGenerator.GetNoise((x + offsetX), (y + offsetY));
             }
         }
 


### PR DESCRIPTION
The offset can be used to center the map on a specific (x, y) coordinate, or to create multiple maps that fit together at the edges. 

The diamond square algorithm unfortunately cannot be used this way. It is possible to create tiled diamond square maps by seeding a new diamond square with data from an adjacent map, but not by simply offsetting the coordinates since you aren't sampling noise like in the FBM generator.